### PR TITLE
Reduce memory requirement of backprojection for CPU and GPU

### DIFF
--- a/ext/MRISubspaceReconCUDAExt/BackProjection.jl
+++ b/ext/MRISubspaceReconCUDAExt/BackProjection.jl
@@ -17,19 +17,19 @@ function MRISubspaceRecon.calculate_backprojection(data::CuArray{Tc,3}, trj::CuA
     data_temp = CuArray{Tc}(undef, sum(nsamp_t))
 
     # Apply sampling mask to data and perform backprojection
-    data_rs = @view data[sample_mask, :]
     threads, blocks = default_launch_config(nsamp_t)
     verbose && println("calculating backprojection...")
     flush(stdout)
-    for icoef ∈ axes(U, 2)
-        t = @elapsed for icoil ∈ axes(data, 3)
-            @cuda threads=threads blocks=blocks multiply_data_with_basis!(data_temp, data_rs, Uc, nsamp_t, cumsum_nsamp, icoef, icoil)
+    t = @elapsed for icoil ∈ axes(data, 3)
+        for icoef ∈ axes(U, 2)
+            copyto!(data_temp, @view data[sample_mask, icoil])
+            @cuda threads=threads blocks=blocks multiply_data_with_basis!(data_temp, Uc, nsamp_t, cumsum_nsamp, icoef)
             MRISubspaceRecon.apply_density_compensation!(data_temp, trj_rs; density_compensation)
             @views NonuniformFFTs.exec_type1!(xbp[img_idx, icoef, icoil], p, data_temp) # type 1: non-uniform points to uniform grid
         end
-        verbose && println("coefficient = $icoef: t = $t s")
-        flush(stdout)
     end
+    verbose && println("time to compute backprojection: t = $t s")
+    flush(stdout)
     return xbp
 end
 
@@ -53,20 +53,20 @@ function MRISubspaceRecon.calculate_backprojection(data::CuArray{Tc,3}, trj::CuA
     data_temp = CuArray{Tc}(undef, sum(nsamp_t))
 
     # Apply sampling sample_mask to data and perform backprojection
-    data_rs = @view data[sample_mask, :]
     threads, blocks = default_launch_config(nsamp_t)
     verbose && println("calculating backprojection...")
     flush(stdout)
-    for icoef ∈ axes(U, 2)
-        t = @elapsed for icoil ∈ eachindex(cmaps)
-            @cuda threads=threads blocks=blocks multiply_data_with_basis!(data_temp, data_rs, Uc, nsamp_t, cumsum_nsamp, icoef, icoil)
+    t = @elapsed for icoil ∈ eachindex(cmaps)
+        for icoef ∈ axes(U, 2)
+            copyto!(data_temp, @view data[sample_mask, icoil])
+            @cuda threads=threads blocks=blocks multiply_data_with_basis!(data_temp, Uc, nsamp_t, cumsum_nsamp, icoef)
             MRISubspaceRecon.apply_density_compensation!(data_temp, trj_rs; density_compensation)
             NonuniformFFTs.exec_type1!(xtmp, p, data_temp) # type 1: non-uniform points to uniform grid
             xbp[img_idx, icoef] .+= conj.(cmaps[icoil]) .* xtmp
         end
-        verbose && println("coefficient = $icoef: t = $t s")
-        flush(stdout)
     end
+    verbose && println("time to compute backprojection: t = $t s")
+    flush(stdout)
     return xbp
 end
 
@@ -82,7 +82,7 @@ end
 ## ##########################################################################
 # Internal helper functions
 #############################################################################
-function multiply_data_with_basis!(data_temp, data, Uc, nsamp_t, cumsum_nsamp, icoef, icoil)
+function multiply_data_with_basis!(data_temp, Uc, nsamp_t, cumsum_nsamp, icoef)
     ik = (blockIdx().x - 1) * blockDim().x + threadIdx().x
     it = (blockIdx().y - 1) * blockDim().y + threadIdx().y
 
@@ -90,7 +90,7 @@ function multiply_data_with_basis!(data_temp, data, Uc, nsamp_t, cumsum_nsamp, i
     if it <= length(nsamp_t)
         if ik <= nsamp_t[it]
             ik_abs = cumsum_nsamp[it] + ik # absolute sample index
-            data_temp[ik_abs] = data[ik_abs, icoil] * Uc[it, icoef]
+            data_temp[ik_abs] *= Uc[it, icoef]
             return
         end
     end

--- a/ext/MRISubspaceReconCUDAExt/NFFTNormalOp.jl
+++ b/ext/MRISubspaceReconCUDAExt/NFFTNormalOp.jl
@@ -120,19 +120,18 @@ function calculate_kernel_noncartesian(img_shape_os, trj::CuArray{T,3}, U::CuArr
     threads_sort = min(max_threads, length(kmask_indcs))
     blocks_sort = ceil.(Int, length(kmask_indcs) ./ threads_sort)
 
-    for ic2 ∈ 1:Ncoeff, ic1 ∈ 1:Ncoeff
+    verbose && println("calculating non-Cartesian kernel...")
+    t = @elapsed for ic2 ∈ 1:Ncoeff, ic1 ∈ 1:Ncoeff
         if ic2 >= ic1 # eval. only upper triangular matrix
-            t = @elapsed begin
-                @cuda threads=threads blocks=blocks multiply_basis_vectors!(S, U, nsamp_t, cumsum_nsamp, ic1, ic2)
+            @cuda threads=threads blocks=blocks multiply_basis_vectors!(S, U, nsamp_t, cumsum_nsamp, ic1, ic2)
 
-                exec_type1!(λ2, nfftplan, vec(S)) # type 1: non-uniform points to uniform grid
-                mul!(λ, fftplan, λ2)
+            exec_type1!(λ2, nfftplan, vec(S)) # type 1: non-uniform points to uniform grid
+            mul!(λ, fftplan, λ2)
 
-                @cuda threads=threads_sort blocks=blocks_sort store_packed_kernel!(Λ, λ, kmask_indcs, ic1, ic2)
-            end
-            verbose && println("ic = ($ic1, $ic2): t = $t s"); flush(stdout)
+            @cuda threads=threads_sort blocks=blocks_sort store_packed_kernel!(Λ, λ, kmask_indcs, ic1, ic2)
         end
     end
+    verbose && println("time to compute kernel: t = $t s")
     return Λ, kmask_indcs
 end
 
@@ -173,7 +172,8 @@ function calculate_kernel_noncartesian(img_shape_os, trj::CuArray{T,3}, U::CuArr
     threads_sort = min(max_threads, length(kmask_indcs))
     blocks_sort = ceil.(Int, length(kmask_indcs) ./ threads_sort)
 
-    for ic2 ∈ 1:Ncoeff, ic1 ∈ 1:Ncoeff
+    verbose && println("calculating non-Cartesian kernel...")
+    t = @elapsed for ic2 ∈ 1:Ncoeff, ic1 ∈ 1:Ncoeff
         if ic2 >= ic1 # eval. only upper triangular matrix
             t = @elapsed begin
                 @cuda threads=threads blocks=blocks multiply_basis_vectors!(S, U, nsamp_t, cumsum_nsamp, ic1, ic2)
@@ -184,9 +184,9 @@ function calculate_kernel_noncartesian(img_shape_os, trj::CuArray{T,3}, U::CuArr
 
                 @cuda threads=threads_sort blocks=blocks_sort store_packed_kernel!(Λ, λ, kmask_indcs, ic1, ic2)
             end
-            verbose && println("ic = ($ic1, $ic2): t = $t s"); flush(stdout)
         end
     end
+    verbose && println("time to compute kernel: t = $t s")
     return Λ, kmask_indcs
 end
 

--- a/src/BackProjection.jl
+++ b/src/BackProjection.jl
@@ -37,25 +37,26 @@ function calculate_backprojection(data::AbstractArray{Tc,3}, trj::AbstractArray{
     Ncoil = size(data, 3)
     xbp = Array{Tc}(undef, img_shape..., Ncoef, Ncoil)
 
-    data_rs = data[sample_mask, :]
-    data_temp = Array{Tc}(undef, sum(sample_mask))
+    data_rs = Array{Tc}(undef, sum(sample_mask))
+    data_temp = similar(data_rs)
 
     img_idx = CartesianIndices(img_shape)
     verbose && println("calculating backprojection...")
     flush(stdout)
-    for icoef ∈ axes(U, 2)
-        t = @elapsed for icoil ∈ axes(data, 3)
+    t = @elapsed for icoil ∈ axes(data, 3)
+        data_rs .= @view data[sample_mask, icoil]
+        for icoef ∈ axes(U, 2)
             for it ∈ axes(data, 2)
                 idx1 = cumsum_nsamp[it]
                 idx2 = cumsum_nsamp[it + 1] - 1
-                @views data_temp[idx1:idx2] .= data_rs[idx1:idx2,icoil] .* conj(U[it,icoef])
+                @views data_temp[idx1:idx2] .= data_rs[idx1:idx2] .* conj(U[it,icoef])
             end
             apply_density_compensation!(data_temp, trj_rs; density_compensation)
             @views NonuniformFFTs.exec_type1!(xbp[img_idx, icoef, icoil], p, data_temp) # type 1: non-uniform points to uniform grid
         end
-        verbose && println("coefficient = $icoef: t = $t s")
-        flush(stdout)
     end
+    verbose && println("time to compute backprojection: t = $t s")
+    flush(stdout)
     return xbp
 end
 
@@ -78,26 +79,27 @@ function calculate_backprojection(data::AbstractArray{Tc,3}, trj::AbstractArray{
     xbp = zeros(Tc, img_shape..., Ncoef)
     xtmp = Array{Tc}(undef, img_shape)
 
-    data_rs = data[sample_mask, :]
-    data_temp = Array{Tc}(undef, sum(sample_mask))
+    data_rs = Array{Tc}(undef, sum(sample_mask))
+    data_temp = similar(data_rs)
 
     img_idx = CartesianIndices(img_shape)
     verbose && println("calculating backprojection...")
     flush(stdout)
-    for icoef ∈ axes(U, 2)
-        t = @elapsed for icoil ∈ eachindex(cmaps)
+    t = @elapsed for icoil ∈ eachindex(cmaps)
+        data_rs .= @view data[sample_mask, icoil]
+        for icoef ∈ axes(U, 2)
              @simd for it ∈ axes(data, 2)
                 idx1 = cumsum_nsamp[it]
                 idx2 = cumsum_nsamp[it + 1] - 1
-                @views data_temp[idx1:idx2] .= data_rs[idx1:idx2,icoil] .* conj(U[it,icoef])
+                @views data_temp[idx1:idx2] .= data_rs[idx1:idx2] .* conj(U[it,icoef])
             end
             apply_density_compensation!(data_temp, trj_rs; density_compensation)
             NonuniformFFTs.exec_type1!(xtmp, p, data_temp) # type 1: non-uniform points to uniform grid
             xbp[img_idx, icoef] .+= conj.(cmaps[icoil]) .* xtmp
         end
-        verbose && println("coefficient = $icoef: t = $t s")
-        flush(stdout)
     end
+    verbose && println("time to compute backprojection: t = $t s")
+    flush(stdout)
     return xbp
 end
 

--- a/src/FFTNormalOp.jl
+++ b/src/FFTNormalOp.jl
@@ -78,11 +78,12 @@ struct _FFTNormalOp{S,ΛType,T,N,E,F,G}
     cmaps::G
 end
 
-function calculate_kernel_cartesian(img_shape, trj, U; sample_mask=trues(size(trj)[2:end]))
+function calculate_kernel_cartesian(img_shape, trj, U; sample_mask=trues(size(trj)[2:end]), verbose=false)
     Ncoeff = size(U, 2)
     Λ = zeros(eltype(U), Ncoeff, Ncoeff, img_shape...)
 
-    Threads.@threads for ic ∈ CartesianIndices((Ncoeff, Ncoeff))
+    verbose && println("calculating Cartesian kernel...")
+    t = @elapsed Threads.@threads for ic ∈ CartesianIndices((Ncoeff, Ncoeff))
         for it ∈ axes(U, 1), is ∈ axes(trj, 2)
             if sample_mask[is, it]
                 k_idx = ntuple(j -> mod1(Int(trj[j, is, it]) - img_shape[j] ÷ 2, img_shape[j]), length(img_shape)) # incorporates ifftshift
@@ -93,6 +94,7 @@ function calculate_kernel_cartesian(img_shape, trj, U; sample_mask=trues(size(tr
             end
         end
     end
+    verbose && println("time to compute kernel: t = $t s")
     return Λ
 end
 

--- a/src/NFFTNormalOp.jl
+++ b/src/NFFTNormalOp.jl
@@ -145,26 +145,25 @@ function calculate_kernel_noncartesian(img_shape_os, trj::AbstractArray{T,3}, U:
     # Evaluating only the upper triangular matrix assumes that the PSF from the rightmost voxel to the leftmost voxel is the adjoint of the PSF in the opposite direction.
     # For the outmost voxel, this is not correct, but the resulting images are virtually identical in our test cases.
     # To avoid this error, remove the `if ic2 >= ic1` and the `Λ[ic2,ic1,it] = conj.(λ[kmask_indcs[it]])` statements at the cost of computation time.
-    for ic2 ∈ axes(Λ, 2), ic1 ∈ axes(Λ, 1)
+    verbose && println("calculating non-Cartesian kernel...")
+    t = @elapsed for ic2 ∈ axes(Λ, 2), ic1 ∈ axes(Λ, 1)
         if ic2 >= ic1 # eval. only upper triangular matrix
-            t = @elapsed begin
-                @simd for it ∈ axes(U,1)
-                    idx1 = cumsum_nsamp[it]
-                    idx2 = cumsum_nsamp[it + 1] - 1
-                    @inbounds S[idx1:idx2] .= conj(U[it,ic1]) * U[it,ic2]
-                end
-
-                NonuniformFFTs.exec_type1!(λ2, nfftplan, vec(S)) # type 1: non-uniform points to uniform grid
-                mul!(λ, fftplan, λ2)
-
-                Threads.@threads for it ∈ eachindex(kmask_indcs)
-                    @inbounds Λ[ic2,ic1,it] = conj.(λ[kmask_indcs[it]])
-                    @inbounds Λ[ic1,ic2,it] =       λ[kmask_indcs[it]]
-                end
+            @simd for it ∈ axes(U,1)
+                idx1 = cumsum_nsamp[it]
+                idx2 = cumsum_nsamp[it + 1] - 1
+                @inbounds S[idx1:idx2] .= conj(U[it,ic1]) * U[it,ic2]
             end
-            verbose && println("ic = ($ic1, $ic2): t = $t s"); flush(stdout)
+
+            NonuniformFFTs.exec_type1!(λ2, nfftplan, vec(S)) # type 1: non-uniform points to uniform grid
+            mul!(λ, fftplan, λ2)
+
+            Threads.@threads for it ∈ eachindex(kmask_indcs)
+                @inbounds Λ[ic2,ic1,it] = conj.(λ[kmask_indcs[it]])
+                @inbounds Λ[ic1,ic2,it] =       λ[kmask_indcs[it]]
+            end
         end
     end
+    verbose && println("time to compute kernel: t = $t s")
     return Λ, kmask_indcs
 end
 
@@ -200,27 +199,26 @@ function calculate_kernel_noncartesian(img_shape_os, trj::AbstractArray, U::Abst
 
     # Evaluating only the upper triangular matrix assumes that the PSF from the rightmost voxel to the leftmost voxel is the adjoint of the PSF in the opposite direction.
     # For the outmost voxel, this is not correct, but the resulting images are virtually identical in our test cases.
-    for ic2 ∈ axes(Λ, 2), ic1 ∈ axes(Λ, 1)
+    verbose && println("calculating non-Cartesian kernel...")
+    t = @elapsed for ic2 ∈ axes(Λ, 2), ic1 ∈ axes(Λ, 1)
         if ic2 >= ic1 # eval. only upper triangular matrix
-            t = @elapsed begin
-                @simd for it ∈ axes(U,1)
-                    idx1 = cumsum_nsamp[it]
-                    idx2 = cumsum_nsamp[it + 1] - 1
-                    @inbounds S[idx1:idx2] .= U[it,ic1] * U[it,ic2]
-                end
-
-                NonuniformFFTs.exec_type1!(λ2, nfftplan, vec(S))
-                λ2 .= conj.(λ2) # conjugate input to flip the sign of the exponential in brfft
-                mul!(λ, brfftplan, λ2)
-
-                Threads.@threads for it ∈ eachindex(kmask_indcs)
-                    @inbounds Λ[ic2,ic1,it] = λ[kmask_indcs[it]]
-                    @inbounds Λ[ic1,ic2,it] = λ[kmask_indcs[it]]
-                end
+            @simd for it ∈ axes(U,1)
+                idx1 = cumsum_nsamp[it]
+                idx2 = cumsum_nsamp[it + 1] - 1
+                @inbounds S[idx1:idx2] .= U[it,ic1] * U[it,ic2]
             end
-            verbose && println("ic = ($ic1, $ic2): t = $t s"); flush(stdout)
+
+            NonuniformFFTs.exec_type1!(λ2, nfftplan, vec(S))
+            λ2 .= conj.(λ2) # conjugate input to flip the sign of the exponential in brfft
+            mul!(λ, brfftplan, λ2)
+
+            Threads.@threads for it ∈ eachindex(kmask_indcs)
+                @inbounds Λ[ic2,ic1,it] = λ[kmask_indcs[it]]
+                @inbounds Λ[ic1,ic2,it] = λ[kmask_indcs[it]]
+            end
         end
     end
+    verbose && println("time to compute kernel: t = $t s")
     return Λ, kmask_indcs
 end
 


### PR DESCRIPTION
Tested all options in terms of speed and memory usage for CPU and GPU. Both are on par in times of speed with the old code. Memory usage is reduced. Made print timings consistent between CPU/GPU interfaces.